### PR TITLE
fix: show non-p block elements in lists

### DIFF
--- a/src/helpers/render-document-file.js
+++ b/src/helpers/render-document-file.js
@@ -85,9 +85,49 @@ export const buildImage = async (docxDocumentInstance, vNode, maximumWidth = nul
   }
 };
 
-export const buildList = async (vNode, docxDocumentInstance, xmlFragment) => {
-  const listElements = [];
+const buildListParagraphChildren = (childVNode) => {
+  if (isVText(childVNode)) {
+    return [childVNode];
+  }
 
+  if (isVNode(childVNode)) {
+    if (childVNode.tagName.toLowerCase() === 'li') {
+      // Not sure if this condition can be reached since we're catching it in buildListFallbackNode
+      return [...childVNode.children];
+    }
+
+    return [childVNode];
+  }
+
+  // Will be an empty paragraph
+  return [];
+};
+
+const buildListFallbackNode = (childVNode) => {
+  // childVNode is not nested list (ol or ul). Parent is not p
+  const listParagraphChildren = buildListParagraphChildren(childVNode);
+  const paragraphVNode = new VNode('p', null, listParagraphChildren);
+
+  if (isVNode(childVNode)) {
+    if (childVNode.tagName.toLowerCase() === 'li') {
+      // It's an li, return as is
+      return childVNode;
+    }
+
+    if (childVNode.tagName.toLowerCase() !== 'p') {
+      // It's a VNode, but something else. Create a new p VNode
+      return paragraphVNode;
+    }
+
+    // It's a p, return as is
+    return childVNode;
+  }
+
+  // It's something else, create a new p VNode
+  return paragraphVNode;
+};
+
+export const buildList = async (vNode, docxDocumentInstance, xmlFragment) => {
   let vNodeObjects = [
     {
       node: vNode,
@@ -121,6 +161,7 @@ export const buildList = async (vNode, docxDocumentInstance, xmlFragment) => {
     ) {
       const tempVNodeObjects = tempVNodeObject.node.children.reduce((accumulator, childVNode) => {
         if (['ul', 'ol'].includes(childVNode.tagName)) {
+          // childVNode is a nested list, add 1 to level
           accumulator.push({
             node: childVNode,
             level: tempVNodeObject.level + 1,
@@ -130,44 +171,21 @@ export const buildList = async (vNode, docxDocumentInstance, xmlFragment) => {
               childVNode.properties
             ),
           });
+        } else if (
+          accumulator.length > 0 &&
+          isVNode(accumulator[accumulator.length - 1].node) &&
+          accumulator[accumulator.length - 1].node.tagName.toLowerCase() === 'p'
+        ) {
+          // Previous childVNode is a paragraph, assume inline formatting and append current childVNode to the paragraph
+          accumulator[accumulator.length - 1].node.children.push(childVNode);
         } else {
-          // eslint-disable-next-line no-lonely-if
-          if (
-            accumulator.length > 0 &&
-            isVNode(accumulator[accumulator.length - 1].node) &&
-            accumulator[accumulator.length - 1].node.tagName.toLowerCase() === 'p'
-          ) {
-            accumulator[accumulator.length - 1].node.children.push(childVNode);
-          } else {
-            const paragraphVNode = new VNode(
-              'p',
-              null,
-              // eslint-disable-next-line no-nested-ternary
-              isVText(childVNode)
-                ? [childVNode]
-                : // eslint-disable-next-line no-nested-ternary
-                isVNode(childVNode)
-                ? childVNode.tagName.toLowerCase() === 'li'
-                  ? [...childVNode.children]
-                  : [childVNode]
-                : []
-            );
-            accumulator.push({
-              // eslint-disable-next-line prettier/prettier, no-nested-ternary
-              node: isVNode(childVNode)
-                ? // eslint-disable-next-line prettier/prettier, no-nested-ternary
-                  childVNode.tagName.toLowerCase() === 'li'
-                  ? childVNode
-                  : childVNode.tagName.toLowerCase() !== 'p'
-                  ? paragraphVNode
-                  : childVNode
-                : // eslint-disable-next-line prettier/prettier
-                  paragraphVNode,
-              level: tempVNodeObject.level,
-              type: tempVNodeObject.type,
-              numberingId: tempVNodeObject.numberingId,
-            });
-          }
+          // Handles li. Also handles 'other' by creating a new paragraph
+          accumulator.push({
+            node: buildListFallbackNode(childVNode),
+            level: tempVNodeObject.level,
+            type: tempVNodeObject.type,
+            numberingId: tempVNodeObject.numberingId,
+          });
         }
 
         return accumulator;
@@ -175,8 +193,6 @@ export const buildList = async (vNode, docxDocumentInstance, xmlFragment) => {
       vNodeObjects = tempVNodeObjects.concat(vNodeObjects);
     }
   }
-
-  return listElements;
 };
 
 async function findXMLEquivalent(docxDocumentInstance, vNode, xmlFragment) {


### PR DESCRIPTION
https://persuit.atlassian.net/browse/DEV-13210

This is a partial fix for block elements within lists not being rendered into the docx.

Example of problematic code:
```html
<ul>
  <li>This works</li>
  <li><div>This does not work</div></li>
</ul>
```

The partial fix is to catch those elements and convert to plain `new VText(plainString)`. Unfortunately subsequent block elements within the li still do not show

```html
<ul>
  <li>This works</li>
  <li><div>This does now work</div></li>
  <li>
    <h1>This does now work</h1>
    <p>I still do not render</p>
    <p>I still do not render</p>
  </li>
</ul>
```

**Given this html:**
![Screenshot 2024-12-05 at 8 49 58 am](https://github.com/user-attachments/assets/becbc70d-ea2d-4ad4-9f6f-a52989692f35)

**Before the Word doc showed:**
![Screenshot 2024-12-05 at 8 53 06 am](https://github.com/user-attachments/assets/f2553f47-ee7d-456f-a989-031d0fe5f974)

**Now the Word doc shows**
![Screenshot 2024-12-05 at 8 50 13 am](https://github.com/user-attachments/assets/f23fcc64-5072-4aab-9083-8d3bc82a56d7)
