### PR TITLE
chore: package version bump 1.0.2 to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@persuit/html-to-docx",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "HTML to DOCX converter",
   "keywords": [
     "html",


### PR DESCRIPTION
Patch includes:
- 7b7f3a8 fix: show non-p block elements in lists