### PR TITLE
fix: update package-lock with version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@persuit/html-to-docx",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@persuit/html-to-docx",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@oozcitak/dom": "1.15.6",
         "@oozcitak/util": "8.3.4",


### PR DESCRIPTION
Previous PR updated `package.json` but didn't run `npm install` to update `package-lock`