### PR TITLE
chore: bump version from 1.0.3 to 1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@persuit/html-to-docx",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@persuit/html-to-docx",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@oozcitak/dom": "1.15.6",
         "@oozcitak/util": "8.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@persuit/html-to-docx",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "HTML to DOCX converter",
   "keywords": [
     "html",


### PR DESCRIPTION
Previous push (v1.0.3) to the Persuit private NPM registry had an incorrect build. It has been removed.

This is a patch version bump to allow re-release of the same changes.